### PR TITLE
Change the config port for the gateway

### DIFF
--- a/complete/src/main/resources/application.yml
+++ b/complete/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 server:
-  port: 9999
+  port: 8080


### PR DESCRIPTION
When following the tutorial it says to use port 8080 which does not work.  Inside the config its 9999 so I changed it to 8080 to match tutorial.  I have linked the tutorial [here](https://spring.io/guides/gs/gateway/)