### PR TITLE
Fix typo in guide's code

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -187,7 +187,7 @@ public RouteLocator myRoutes(RouteLocatorBuilder builder) {
             .uri("http://httpbin.org:80"))
         .route(p -> p
             .host("*.circuitbreaker.com")
-            .filters(f -> f.circuitbreaker(config -> config
+            .filters(f -> f.circuitBreaker(config -> config
                 .setName("mycmd")
                 .setFallbackUri("forward:/fallback")))
             .uri("http://httpbin.org:80"))

--- a/README.adoc
+++ b/README.adoc
@@ -159,6 +159,14 @@ $ curl --dump-header - --header 'Host: www.circuitbreaker.com' http://localhost:
 
 NOTE: We use `--dump-header` to see the response headers. The `-` after `--dump-header`
 tells cURL to print the headers to stdout.
+NOTE: In some cases, you'd get an error saying that ReactiveResilience4JCircuitBreakerFactory not found. A workaround is to add this bean to your code:
+----
+@Bean
+public ReactiveResilience4JCircuitBreakerFactory factory()
+{
+    return new ReactiveResilience4JCircuitBreakerFactory();
+}
+----
 
 After using this command, you should see the following in your terminal:
 

--- a/README.adoc
+++ b/README.adoc
@@ -175,6 +175,15 @@ After using this command, you should see the following in your terminal:
 HTTP/1.1 504 Gateway Timeout
 content-length: 0
 ----
+NOTE: You can also get an Error saying: 
+----
+socket hang up
+----
+, and sometimes: 
+----
+curl: (52) Empty reply from server
+----
+where the server effectively closes connection immediately
 
 As you can see the circuit breaker timed out while waiting for the response from HTTPBin. When the circuit breaker times out,
 we can optionally provide a fallback so that clients do not receive a `504` but something


### PR DESCRIPTION
Fix to correct method name circuitBreaker instead of circuitbreaker