### PR TITLE
correct secund f.circuitBreaker(

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -210,7 +210,7 @@ public RouteLocator myRoutes(RouteLocatorBuilder builder) {
             .uri("http://httpbin.org:80"))
         .route(p -> p
             .host("*.circuitbreaker.com")
-            .filters(f -> f.circuitbreaker(config -> config
+            .filters(f -> f.circuitBreaker(config -> config
                 .setName("mycmd")
                 .setFallbackUri("forward:/fallback")))
             .uri("http://httpbin.org:80"))


### PR DESCRIPTION
As Ryan corrected the first "f.circuitBreaker(" ('B' upcase), there was a secund to correct