### PR TITLE
Updated dependencies to match what is provided from Spring Initializr

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,9 @@ You will build a gateway using https://cloud.spring.io/spring-cloud-gateway/[Spr
 
 == What You Need
 
-:java_version: 1.8
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/prereq_editor_jdk_buildtools.adoc[]
+* About 15 minutes
+* A favorite text editor or IDE
+* https://www.oracle.com/java/technologies/downloads/[Java 17+]
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/how_to_complete_this_guide.adoc[]
 
@@ -113,20 +114,6 @@ potentially behave poorly and affect our clients, we might want to wrap the rout
 in circuit breakers. You can do so in the Spring Cloud Gateway by using the Resilience4J Spring Cloud CircuitBreaker implementation.
 This is implemented through a simple filter that you can add to your requests.
 We can create another route to demonstrate this.
-
-To use this filter you need to add the reactive Resilience4J CircuitBreaker dependency to your classpath.
-
-`pom.xml`
-[source,java,tabsize=2]
-----
-include::complete/pom.xml[tags=dependency]
-----
-
-`build.gradle`
-[source,java,tabsize=2]
-----
-include::complete/build.gradle[tags=dependency]
-----
 
 In the next example, we use HTTPBin's delay API, which waits a certain number of
 seconds before sending a response. Since this API could potentially take a long

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -21,12 +21,10 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
-	// tag::dependency[]
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
-	// end::dependency[]
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -20,14 +20,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
 		</dependency>
-		<!-- tag::dependency[] -->
-		<dependency>
-    		<groupId>org.springframework.cloud</groupId>
-    		<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
-		</dependency>
-		<!-- end::dependency[] -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>
@@ -36,6 +30,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/complete/src/main/resources/application.yml
+++ b/complete/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 server:
-  port: 9999
+  port: 8080

--- a/complete/src/test/java/gateway/ApplicationTest.java
+++ b/complete/src/test/java/gateway/ApplicationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -21,9 +21,10 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -20,7 +20,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -30,6 +30,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
After the addition of [`spring-cloud-starter-gateway-mvc` to Spring Initializr](https://github.com/spring-io/start.spring.io/issues/1367#issuecomment-1845505660), the dependencies listed in the build files in this guide no longer match what was provided from Spring Initializr. This PR makes sure that the `complete` and `initial` folders have the same dependencies that are generated from Spring Initializr.

